### PR TITLE
Improve error handling, take &str instead of String in lookup method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["vikaton <root@stackin.money>"]
 
 [dependencies]
 rustc-serialize = "*"
+error-chain = "0.5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,1 @@
+error_chain!{}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![recursion_limit = "1024"]
+#[macro_use]
+extern crate error_chain;
+
 extern crate rustc_serialize;
 
 use std::net::TcpStream;
@@ -5,20 +9,23 @@ use std::io::prelude::*;
 use std::collections::HashMap;
 use rustc_serialize::json;
 
-pub struct WhoIs {
-    server: String,
+pub mod errors;
+use errors::*;
+
+pub struct WhoIs<'a> {
+    server: &'a str,
     follow: isize,
     new_whois: String,
-    query: String
+    query: String,
 }
 
-impl WhoIs {
-    pub fn new(x: String)-> WhoIs {
+impl<'a> WhoIs<'a> {
+    pub fn new(x: &'a str) -> WhoIs<'a> {
         WhoIs {
             server: x,
             follow: 0,
             new_whois: String::new(),
-            query: String::new()
+            query: String::new(),
         }
     }
     ///
@@ -28,70 +35,76 @@ impl WhoIs {
     ///  If there is another whois server in the whois data then it calls 'parse_whois'
     ///  so it can get the whois data from that
     ///
-    pub fn lookup(&mut self) -> Result<String, &'static str> {
+    pub fn lookup(&mut self) -> Result<String> {
         let mut result = String::new();
         let mut server = self.new_whois.to_owned();
         let target = self.server.to_owned();
         let tld = match target.split(".").last() {
             Some(tld) => tld,
-            None => return Err("Invalid URL?")
+            None => return Err("Invalid URL?".into()),
         };
         if self.follow == 0 {
             self.query = match tld {
                 "com" | "net" => "DOMAIN ".into(),
-                _ => "".into()
+                _ => "".into(),
             };
-            server = self.get_server(&tld).unwrap();
+            server = self.get_server(&tld).expect(&format!("Failed to get server for {}", tld));
         }
-        let mut client = TcpStream::connect((&*server, 43u16)).expect("Could not connect to server!!");
-        match client.write_all(format!("{}{}\n", self.query, target).as_bytes()) {
-            Ok(_) => (),
-            Err(_) => return Err("Could not write to client {}")
-        }
-        client.read_to_string(&mut result).unwrap();
+        let mut client = try!(TcpStream::connect((&*server, 43u16))
+                                  .chain_err(|| "Could not connect to server!!"));
+
+        try!(client.write_all(format!("{}{}\n", self.query, target).as_bytes())
+                   .chain_err(|| "Could not write to client {}"));
+
+        try!(client.read_to_string(&mut result)
+                   .chain_err(|| "Failed to read to string"));
+
         if result.contains("Whois Server:") {
             self.query = "".into();
             self.follow += 1;                                             // If there is another Whois Server, take that server and pass it to
-            return Ok(self.parse_whois(&*result))                             // pass it to parse_whois
-        }
-        else {
-            let clean = result.replace("http:", "").replace("https:",""); // I'm splitting via ':' so the urls needs to be omitted
-            return Ok(self.parse_data(clean))
+            Ok(self.parse_whois(&*result))                             // pass it to parse_whois
+        } else {
+            let clean = result.replace("http:", "").replace("https:", ""); // I'm splitting via ':' so the urls needs to be omitted
+            self.parse_data(clean)
         }
     }
-    fn parse_data(&self, result: String) -> String {
+    fn parse_data(&self, result: String) -> Result<String> {
         let mut data = HashMap::new();
         for c in result.lines() {
             let mut line = c.split(':');
-            let key = line.next().unwrap();
+            let key = line.next().expect("Failed to get key");
             let value = match line.next() {
                 Some(value) => value,
-                None => continue
+                None => continue,
             };
             data.insert(key, value.trim());
         }
-        return json::encode(&data).unwrap()
+        json::encode(&data).chain_err(|| "Could not encode data as json")
     }
     ///
     /// This function calls lookup() again if there is a another whois server
     ///
     ///
     fn parse_whois(&mut self, result: &str) -> String {
-        let line = &result.lines().find(|i| i.contains("Whois Server:")).unwrap();
+        let line = &result.lines()
+                          .find(|i| i.contains("Whois Server:"))
+                          .expect("Could not find wh");
         let target = line.split_whitespace().last().unwrap().to_owned();
         self.new_whois = target;
-        self.lookup().unwrap()
+        self.lookup().expect("Failed lookup in parse_whois")
     }
 
-    fn get_server(&self, target: &str) -> Result<String, &'static str> {
+    fn get_server(&self, target: &str) -> Result<String> {
         let mut result = String::new();
-        let mut client = TcpStream::connect("whois.iana.org:43").expect("Could not connect to server!");
-        match client.write_all(format!("{}\n", target).as_bytes()) {
-            Ok(_) => (),
-            Err(_) => return Err("Could not write to client")
-        }
-        client.read_to_string(&mut result).unwrap();
-        let line = &result.lines().find(|i| i.starts_with("whois:")).unwrap();
+        let mut client = try!(TcpStream::connect("whois.iana.org:43")
+                                  .chain_err(|| "Could not connect to server!"));
+
+        try!(client.write_all(format!("{}\n", target).as_bytes())
+                   .chain_err(|| "Could not write to client"));
+
+        try!(client.read_to_string(&mut result).chain_err(|| "Failed to read result to string"));
+        // println!("{:?}", result);
+        let line = &result.lines().find(|i| i.starts_with("whois:")).expect("Couldnt get wh");
         let foo = line.split_whitespace().last().unwrap().to_owned();
         Ok(foo)
     }


### PR DESCRIPTION
I quickly added some error handling to the code. There are a few unwraps, but I don't know if they'll ever get hit so I didn't bother cleaning those up.

I've also changed lookup to take &str, as this is more generic than String, and won't require the caller to make a copy.

I think String should autoderef to &str so that shouldn't make a difference, but it may be a breaking change.
